### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ myContract.action(transaction_value, gasPrice = transaction_gaspr)
 
 In the above test case, 50 ETH were sent in to the LeverageWallet
 After a single transaction the accounts ETH balance grew to 128 ETH (118 + 10) with an outstanding DAI debt of 141,160 DAI.
-50 ETH were leveraged to 128, which results in a laverage-factor of about 2.57x.
+50 ETH were leveraged to 128, which results in a leverage-factor of about 2.57x.
 
 The fact that under-collateralized vaults are in risk of liquidations was completely ignored.
 This should definatelly not be used in production environments!


### PR DESCRIPTION
I fixed a typo on README.md file :
* laverage -> leverage